### PR TITLE
Fix Time Tracking DOM

### DIFF
--- a/time-tracker-webapps/src/main/webapp/timeTracking.html
+++ b/time-tracker-webapps/src/main/webapp/timeTracking.html
@@ -1,5 +1,5 @@
 <div class="VuetifyApp">
-    <div id="timeTrackingApp" class=timeTrackingApp">
+    <div id="timeTrackingApp" class="timeTrackingApp">
 
     </div>
 </div>


### PR DESCRIPTION
In fact when a braked DOM is served in page, the skeleton cache V2 will not work properly and some elements gets lost and not displayed.
Consequently, some other elements aren't displayed in Topbar.