### PR TITLE
TASK-53062 Upgrade to Hibernate 5.6

### DIFF
--- a/time-tracker-services/pom.xml
+++ b/time-tracker-services/pom.xml
@@ -36,15 +36,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>jsr250-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>jsr311-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.ws</groupId>
       <artifactId>exo.ws.rest.core</artifactId>
       <scope>provided</scope>
@@ -74,7 +65,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <artifactId>social-component-service</artifactId>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
@@ -137,11 +127,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <artifactId>exo.tool.framework.junit</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/ActivityCodeEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/ActivityCodeEntity.java
@@ -36,7 +36,7 @@ import lombok.Data;
 public class ActivityCodeEntity {
 
   @Id
-  @SequenceGenerator(name = "SEQ_ACTIVITY_CODE_ID", sequenceName = "SEQ_ACTIVITY_CODE_ID")
+  @SequenceGenerator(name = "SEQ_ACTIVITY_CODE_ID", sequenceName = "SEQ_ACTIVITY_CODE_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_ACTIVITY_CODE_ID")
   @Column(name = "ID")
   private Long   id;

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/ActivityEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/ActivityEntity.java
@@ -36,7 +36,7 @@ import lombok.Data;
 public class ActivityEntity {
 
   @Id
-  @SequenceGenerator(name = "SEQ_PROJECT_ID", sequenceName = "SEQ_PROJECT_ID")
+  @SequenceGenerator(name = "SEQ_PROJECT_ID", sequenceName = "SEQ_PROJECT_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_PROJECT_ID")
   @Column(name = "ID")
   private Long          id;

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/ActivityRecordEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/ActivityRecordEntity.java
@@ -41,7 +41,7 @@ public class ActivityRecordEntity {
 
 
   @Id
-  @SequenceGenerator(name = "SEQ_PROJECT_ID", sequenceName = "SEQ_PROJECT_ID")
+  @SequenceGenerator(name = "SEQ_PROJECT_ID", sequenceName = "SEQ_PROJECT_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_PROJECT_ID")
   @Column(name = "ID")
   private Long           id;

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/ClientEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/ClientEntity.java
@@ -36,7 +36,7 @@ import lombok.Data;
 public class ClientEntity {
 
   @Id
-  @SequenceGenerator(name = "SEQ_CLIENT_ID", sequenceName = "SEQ_CLIENT_ID")
+  @SequenceGenerator(name = "SEQ_CLIENT_ID", sequenceName = "SEQ_CLIENT_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_CLIENT_ID")
   @Column(name = "ID")
   private Long   id;

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/FeatureEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/FeatureEntity.java
@@ -36,7 +36,7 @@ import lombok.Data;
 public class FeatureEntity {
 
   @Id
-  @SequenceGenerator(name = "SEQ_FEATURE_ID", sequenceName = "SEQ_FEATURE_ID")
+  @SequenceGenerator(name = "SEQ_FEATURE_ID", sequenceName = "SEQ_FEATURE_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_FEATURE_ID")
   @Column(name = "ID")
   private Long   id;

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/FilterEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/FilterEntity.java
@@ -36,7 +36,7 @@ import javax.persistence.*;
 public class FilterEntity {
 
   @Id
-  @SequenceGenerator(name = "SEQ_FILTER_ID", sequenceName = "SEQ_FILTER_ID")
+  @SequenceGenerator(name = "SEQ_FILTER_ID", sequenceName = "SEQ_FILTER_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_FILTER_ID")
   @Column(name = "ID")
   private Long   id;

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/FilterFieldEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/FilterFieldEntity.java
@@ -36,7 +36,7 @@ import javax.persistence.*;
 public class FilterFieldEntity {
 
   @Id
-  @SequenceGenerator(name = "SEQ_FILTER_ID", sequenceName = "SEQ_FILTER_ID")
+  @SequenceGenerator(name = "SEQ_FILTER_ID", sequenceName = "SEQ_FILTER_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_FILTER_ID")
   @Column(name = "ID")
   private Long   id;

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/ProjectEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/ProjectEntity.java
@@ -36,7 +36,7 @@ import lombok.Data;
 public class ProjectEntity {
 
   @Id
-  @SequenceGenerator(name = "SEQ_PROJECT_ID", sequenceName = "SEQ_PROJECT_ID")
+  @SequenceGenerator(name = "SEQ_PROJECT_ID", sequenceName = "SEQ_PROJECT_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_PROJECT_ID")
   @Column(name = "ID")
   private Long         id;

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/SalesOrderEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/SalesOrderEntity.java
@@ -39,7 +39,7 @@ import lombok.Data;
 public class SalesOrderEntity {
 
   @Id
-  @SequenceGenerator(name = "SEQ_SALES_ORDER_ID", sequenceName = "SEQ_SALES_ORDER_ID")
+  @SequenceGenerator(name = "SEQ_SALES_ORDER_ID", sequenceName = "SEQ_SALES_ORDER_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SALES_ORDER_ID")
   @Column(name = "ID")
   private Long         id;

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/SubActivityCodeEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/SubActivityCodeEntity.java
@@ -36,7 +36,7 @@ import lombok.Data;
 public class SubActivityCodeEntity {
 
   @Id
-  @SequenceGenerator(name = "SEQ_SUB_ACTIVITY_CODE_ID", sequenceName = "SEQ_SUB_ACTIVITY_CODE_ID")
+  @SequenceGenerator(name = "SEQ_SUB_ACTIVITY_CODE_ID", sequenceName = "SEQ_SUB_ACTIVITY_CODE_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SUB_ACTIVITY_CODE_ID")
   @Column(name = "ID")
   private Long   id;

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/SubTypeEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/SubTypeEntity.java
@@ -36,7 +36,7 @@ import lombok.Data;
 public class SubTypeEntity {
 
   @Id
-  @SequenceGenerator(name = "SEQ_SUB_TYPE_ID", sequenceName = "SEQ_SUB_TYPE_ID")
+  @SequenceGenerator(name = "SEQ_SUB_TYPE_ID", sequenceName = "SEQ_SUB_TYPE_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_SUB_TYPE_ID")
   @Column(name = "ID")
   private Long   id;

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/TypeEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/TypeEntity.java
@@ -36,7 +36,7 @@ import lombok.Data;
 public class TypeEntity {
 
   @Id
-  @SequenceGenerator(name = "SEQ_TYPE_ID", sequenceName = "SEQ_TYPE_ID")
+  @SequenceGenerator(name = "SEQ_TYPE_ID", sequenceName = "SEQ_TYPE_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_TYPE_ID")
   @Column(name = "ID")
   private Long   id;

--- a/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/WorkTimeEntity.java
+++ b/time-tracker-services/src/main/java/org/exoplatform/timetracker/entity/WorkTimeEntity.java
@@ -41,7 +41,7 @@ import org.exoplatform.timetracker.dto.Office;
 public class WorkTimeEntity {
 
   @Id
-  @SequenceGenerator(name = "SEQ_WORK_TIME_ID", sequenceName = "SEQ_WORK_TIME_ID")
+  @SequenceGenerator(name = "SEQ_WORK_TIME_ID", sequenceName = "SEQ_WORK_TIME_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_WORK_TIME_ID")
   @Column(name = "ID")
   private Long         id;

--- a/time-tracker-services/src/test/java/org/exoplatform/timetracker/storage/ClientStorageTest.java
+++ b/time-tracker-services/src/test/java/org/exoplatform/timetracker/storage/ClientStorageTest.java
@@ -16,20 +16,29 @@
 */
 package org.exoplatform.timetracker.storage;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
-
-import org.junit.Before;
-import org.junit.Test;
-
-import org.exoplatform.timetracker.dao.ClientDAO;
-import org.exoplatform.timetracker.dto.Client;
-import org.exoplatform.timetracker.entity.ClientEntity;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.timetracker.dao.ClientDAO;
+import org.exoplatform.timetracker.dto.Client;
+import org.exoplatform.timetracker.entity.ClientEntity;
 
 public class ClientStorageTest {
 
@@ -38,9 +47,17 @@ public class ClientStorageTest {
   private ClientStorage clientStorage;
 
   @Before
-  public void setUp() throws Exception { // NOSONAR
+  public void setUp() {
     clientDAO = mock(ClientDAO.class);
     clientStorage = new ClientStorage(clientDAO);
+    PortalContainer container = PortalContainer.getInstance();
+    ExoContainerContext.setCurrentContainer(container);
+    RequestLifeCycle.begin(container);
+  }
+
+  @After
+  public void tearDown() {
+    RequestLifeCycle.end();
   }
 
   @Test


### PR DESCRIPTION
* To make the upgrade to Hibernate 5.6, this commit will introduce allocationSize parameter in sequences annotations in order to ensure consistency of used IDs for primary keys of tables. In fact, Hibernate 5.6 will cache the  value and increment IDs internally without soliciting database for each ID generation which can lead to an inconsistency, knowing that the created Sequence using Liquibase doesn't increment by 50 (default value of allocationSize).
* Make sure to start a transaction before each unit test
* Delete dropped dependency slf4j-simple