### PR TITLE
MAINT-53302: Fix ckeditor ui styles regression

### DIFF
--- a/time-tracker-webapps/src/main/webapp/css/main.less
+++ b/time-tracker-webapps/src/main/webapp/css/main.less
@@ -4,6 +4,10 @@
   @greyColorLighten1Default
 );
 
+div#middle-topNavigation-container .UIIntermediateContainer > .UIRowContainer {
+  display: flex;
+}
+
 #activityManagementApp {
   padding: 10px;
 }

--- a/time-tracker-webapps/src/main/webapp/vue-app/components/timetracking/TimeTrackingDrawer.vue
+++ b/time-tracker-webapps/src/main/webapp/vue-app/components/timetracking/TimeTrackingDrawer.vue
@@ -345,10 +345,7 @@ export default {
 };
 </script>
 
-<style>
-div#middle-topNavigation-container .UIIntermediateContainer > .UIRowContainer {
-  display: flex;
-}
+<style scoped>
 .actList {
   width: 100%;
 }

--- a/time-tracker-webapps/webpack.dev.js
+++ b/time-tracker-webapps/webpack.dev.js
@@ -26,7 +26,7 @@ module.exports = merge(webpackCommonConfig, {
         timeSheet: './src/main/webapp/vue-app/timeSheet.js'
     },
     output: {
-        path: path.join(exoServerPath, '/time-tracker/'),
+        path: path.join(exoServerPath, '/webapps/time-tracker/'),
         filename: 'js/[name].bundle.js'
     },
     devServer: {


### PR DESCRIPTION
ISSUE: A non scoped styles in the time-tracker addon affected the styles in ckeditor in notes, customer-space.
FIX: This PR should scope the used styles in the time-tracker drawer to prevent changing the styles in other places