### PR TITLE
fix: When opening time tracking application, current month displayed is february - EXO-59485

### DIFF
--- a/time-tracker-webapps/src/main/webapp/vue-app/components/timeSheet/TimeSheet.vue
+++ b/time-tracker-webapps/src/main/webapp/vue-app/components/timeSheet/TimeSheet.vue
@@ -633,7 +633,7 @@ export default {
       this.dateParam = url.searchParams.get('date');
       const date = this.dateParam && new Date(this.dateParam) || new Date();
       const isoDate = date.toISOString();
-      const month = parseInt(isoDate.substring(3, 5));
+      const month = parseInt(isoDate.substring(5, 7));
       const year = parseInt(isoDate.substring(0, 4));
       const startOfMonth = new Date(`${year}-${month}-01 00:00:00Z`);
       const endOfMonth = new Date(`${year}-${month + 1}-01 00:00:00Z`);


### PR DESCRIPTION
Before this fix, the current displayed month was february. It was due to a problem in computing current month from the current date, the substring was done on wrong value. This fix changes how the current month is extracted.