### PR TITLE
fix: Since first of december, timesheet do not load - eXO-61096

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <parent>
         <artifactId>addons-parent-pom</artifactId>
         <groupId>org.exoplatform.addons</groupId>
-        <version>16-M05</version>
+        <version>16-exo-M06</version>
     </parent>
     <groupId>org.exoplatform.addons.time-tracker</groupId>
     <artifactId>time-tracker</artifactId>

--- a/time-tracker-webapps/src/main/webapp/vue-app/components/timeSheet/TimeSheet.vue
+++ b/time-tracker-webapps/src/main/webapp/vue-app/components/timeSheet/TimeSheet.vue
@@ -633,10 +633,16 @@ export default {
       this.dateParam = url.searchParams.get('date');
       const date = this.dateParam && new Date(this.dateParam) || new Date();
       const isoDate = date.toISOString();
-      const month = parseInt(isoDate.substring(5, 7));
-      const year = parseInt(isoDate.substring(0, 4));
+      let month = parseInt(isoDate.substring(5, 7));
+      let year = parseInt(isoDate.substring(0, 4));
       const startOfMonth = new Date(`${year}-${month}-01 00:00:00Z`);
-      const endOfMonth = new Date(`${year}-${month + 1}-01 00:00:00Z`);
+
+      month=month+1;
+      if (month === 13) {
+        month=1;
+        year = year + 1;
+      }
+      const endOfMonth = new Date(`${year}-${month}-01 00:00:00Z`);
       endOfMonth.setMilliseconds(-1);
       this.date = [startOfMonth.toISOString().substring(0, 10), endOfMonth.toISOString().substring(0, 10)];
       setTimeout(() => {


### PR DESCRIPTION
Before this fix, the application timesheet do not load. This was due to date computation : when compute the endDate, we take the month number and add 1. So in december, the month is 13, which not exists This fix adds a module to be sure to have a correct month