### PR TITLE
fix: Update v-alert component for time-tracker - EXO-67601.

### DIFF
--- a/time-tracker-webapps/src/main/webapp/vue-app/components/activityManagement/activities/ActivitiesList.vue
+++ b/time-tracker-webapps/src/main/webapp/vue-app/components/activityManagement/activities/ActivitiesList.vue
@@ -1,12 +1,5 @@
 <template>
   <div>
-    <div
-      v-if="alert"
-      :class="alert_type"
-      class="alert">
-      <i :class="alertIcon"></i>
-      {{ message }}
-    </div>
     <v-flex>
       <v-data-table
         :headers="headers"
@@ -120,10 +113,7 @@ export default {
   },
   data: () => ({
     search: '',
-    alert: false,
     message: '',
-    alert_type: '',
-    alertIcon: '',
     valid: true,
     activities: [],
     editedIndex: -1,
@@ -342,19 +332,20 @@ export default {
         });
     },
     displaySusccessMessage(message) {
-      this.message = message;
-      this.alert_type = 'alert-success';
-      this.alertIcon = 'uiIconSuccess';
-      this.alert = true;
-      setTimeout(() => (this.alert = false), 5000);
+      document.dispatchEvent(new CustomEvent('alert-message', {
+        detail: {
+          alertMessage: message,
+          alertType: 'success',
+        }
+      }));
     },
     displayErrorMessage(message) {
-      this.isUpdating = false;
-      this.message = message;
-      this.alert_type = 'alert-error';
-      this.alertIcon = 'uiIconError';
-      this.alert = true;
-      setTimeout(() => (this.alert = false), 5000);
+      document.dispatchEvent(new CustomEvent('alert-message', {
+        detail: {
+          alertMessage: message,
+          alertType: 'error'
+        }
+      }));
     },
     getTypeTitle(item) {
       const type =  this.fieldList.find(x => x.value === item.type);

--- a/time-tracker-webapps/src/main/webapp/vue-app/components/timeSheetApp.vue
+++ b/time-tracker-webapps/src/main/webapp/vue-app/components/timeSheetApp.vue
@@ -16,14 +16,6 @@
           </v-btn>
         </v-layout>
       </v-container>
-      <div
-        v-if="alert"
-        id
-        :class="alert_type"
-        class="alert">
-        <i :class="alertIcon"></i>
-        {{ message }}
-      </div>
       <time-sheet />
     </main>
   </v-app>
@@ -36,26 +28,24 @@ export default {
     TimeSheet
   },
   data: () => ({
-    alert: false,
     message: '',
-    alert_type: '',
-    alertIcon: '',
   }),
   methods: {
     displaySusccessMessage(message) {
-      this.message = message;
-      this.alert_type = 'alert-success';
-      this.alertIcon = 'uiIconSuccess';
-      this.alert = true;
-      setTimeout(() => (this.alert = false), 5000);
+      document.dispatchEvent(new CustomEvent('alert-message', {
+        detail: {
+          alertMessage: message,
+          alertType: 'success',
+        }
+      }));
     },
     displayErrorMessage(message) {
-      this.isUpdating = false;
-      this.message = message;
-      this.alert_type = 'alert-error';
-      this.alertIcon = 'uiIconError';
-      this.alert = true;
-      setTimeout(() => (this.alert = false), 5000);
+      document.dispatchEvent(new CustomEvent('alert-message', {
+        detail: {
+          alertMessage: message,
+          alertType: 'error'
+        }
+      }));
     },
   },
 };

--- a/time-tracker-webapps/src/main/webapp/vue-app/components/timeTrackingApp.vue
+++ b/time-tracker-webapps/src/main/webapp/vue-app/components/timeTrackingApp.vue
@@ -19,14 +19,6 @@
       
       <time-tracking-drawer ref="timeTrackingDrawer" />
     </main>
-    <div
-      v-if="alert"
-      id
-      :class="alert_type"
-      class="alert">
-      <i :class="alertIcon"></i>
-      {{ message }}
-    </div>
   </v-app>
 </template>
 
@@ -37,10 +29,7 @@ export default {
     TimeTrackingDrawer
   },
   data: () => ({
-    alert: false,
     message: '',
-    alert_type: '',
-    alertIcon: '',
   }),
   
   methods: {
@@ -48,19 +37,20 @@ export default {
       this.$refs.timeTrackingDrawer.open();
     },
     displaySusccessMessage(message) {
-      this.message = message;
-      this.alert_type = 'success';
-      this.alertIcon = 'uiIconSuccess';
-      this.alert = true;
-      setTimeout(() => (this.alert = false), 5000);
+      document.dispatchEvent(new CustomEvent('alert-message', {
+        detail: {
+          alertMessage: message,
+          alertType: 'success',
+        }
+      }));
     },
     displayErrorMessage(message) {
-      this.isUpdating = false;
-      this.message = message;
-      this.alert_type = 'alerterror';
-      this.alertIcon = 'uiIconError';
-      this.alert = true;
-      setTimeout(() => (this.alert = false), 5000);
+      document.dispatchEvent(new CustomEvent('alert-message', {
+        detail: {
+          alertMessage: message,
+          alertType: 'error'
+        }
+      }));
     },
   },
 };


### PR DESCRIPTION
The toast notifications defined didn't rely on the centralized reusable component to display alerts. This PR removes the specific alerts added to reuse the centralized component.