### PR TITLE
fix: can't add a team in activity - EXO-76979.

### DIFF
--- a/time-tracker-webapps/src/main/webapp/vue-app/components/activityManagement/activities/AddActivityDrawer.vue
+++ b/time-tracker-webapps/src/main/webapp/vue-app/components/activityManagement/activities/AddActivityDrawer.vue
@@ -117,7 +117,9 @@
               </option>
             </select>
           </div>
-          <div>
+          <div 
+            id="timeTrackerDivAutoCompleteTeamsList"
+            class="position-relative contactAutoComplete">
             <v-label for="teams">
               {{ $t("exo.timeTracker.activities.addActivitiesDrawer.drawerLabelTeams") }}
             </v-label>
@@ -125,7 +127,9 @@
               ref="select"
               v-model="editedActivity.teams"
               :items="teams"
-              menu-props="closeOnClick"
+              class="ma-0 pa-0"
+              menu-props="{ closeOnClick: true}"
+              attach="#timeTrackerDivAutoCompleteTeamsList"
               outlined
               dense
               chips

--- a/time-tracker-webapps/src/main/webapp/vue-app/components/activityManagement/activities/EditActivityDrawer.vue
+++ b/time-tracker-webapps/src/main/webapp/vue-app/components/activityManagement/activities/EditActivityDrawer.vue
@@ -117,7 +117,9 @@
               </option>
             </select>
           </div>
-          <div>
+          <div 
+            id="timeTrackerDivAutoCompleteTeamsListItems"
+            class="position-relative contactAutoComplete">
             <v-label for="teams">
               {{ $t("exo.timeTracker.activities.editActivitiesDrawer.drawerLabelTeams") }}
             </v-label>
@@ -126,11 +128,13 @@
               v-model="teamIds"
               :items="teams"
               outlined
+              class="ma-0 pa-0"
+              menu-props="{ closeOnClick: true}"
+              attach="#timeTrackerDivAutoCompleteTeamsListItems"
               dense
               chips
               small-chips
               multiple
-              menu-props="closeOnClick"
               item-text="name"
               item-value="id"
               @click.stop />


### PR DESCRIPTION
Before this change, when opening the create/update activity drawer, can't assign a team in an activity. To resolve this problem, add the attach property to the autocomplete component. After this change, create/update activity allow admin to display teams list and select from it.